### PR TITLE
[fix-bad-ascii] Fixing \xE2 byte sequences blowing up Berkshelf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This file is used to list changes made in each version of beaver.
 ## 1.1.0:
 
 * Jeff Ramnani added a great LWRP for tail logs
-* The whole configuration changed to a way more flexible approach that will allow future configuration options in the cookbook without any adjustments (that is the reason for the major version bump too…)
+* The whole configuration changed to a way more flexible approach that will allow future configuration options in the cookbook without any adjustments (that is the reason for the major version bump too)
 
 ## 0.1.0:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 beaver Cookbook
 ===============
 
-Install [beaver](https://github.com/josegonzalez/beaver) — the python daemon that munches on logs and sends their
+Install [beaver](https://github.com/josegonzalez/beaver) - the python daemon that munches on logs and sends their
 contents to logstash.
 
 Requirements


### PR DESCRIPTION
Berkshelf is not able to upload this cookbook due to unicode/nonascii characters in the README & Changelog. Once I removed them a berks upload beaver worked fine.
