### PR TITLE
allow any parameters in log file config

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -55,6 +55,15 @@ service 'beaver' do
   action :nothing
 end
 
+logFiles = node['beaver']['files'].map { |each|
+  path = each["path"]
+  options = each.reject { |key, value| key == "path" }
+  {
+    "path" => path,
+    "options" => options
+  }
+}
+
 template "#{node['beaver']['config_path']}/#{node['beaver']['config_file']}" do
   source 'beaver.conf.erb'
   owner 'root'
@@ -62,7 +71,7 @@ template "#{node['beaver']['config_path']}/#{node['beaver']['config_file']}" do
   mode 00644
   variables(
     :beaver => node['beaver']['configuration'],
-    :files => node['beaver']['files']
+    :files => logFiles
   )
   notifies :restart, "service[beaver]"
 end

--- a/templates/default/beaver.conf.erb
+++ b/templates/default/beaver.conf.erb
@@ -5,9 +5,10 @@
 <% @beaver.each do |key, value| %>
 <%= "#{key}: #{value}" %>
 <% end %>
-<% @files.each do |file| %>
 
-[<%= file['path'] %>]
-type: <%= file['type'] %>
-tags: <%= file['tags'] %>
+<% @files.each do |file| %>
+[<%= file["path"] %>]
+  <% file["options"].each do |key, value| %>
+<%= "#{key}: #{value}" %>
+  <% end %>
 <% end %>


### PR DESCRIPTION
Besides `tags` and `type` beaver supports other log file options like `add_field`, `format`, ...

http://beaver.readthedocs.org/en/latest/user/usage.html#configuration-files
