### PR TITLE
Use newer poise-python cookbook instead of python

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The following platform families are supported:
 
 ### Cookbooks
 
-* python (to use the pip LWRP)
+* poise-python (to use the python_package LWRP)
 
 Attributes
 ----------
@@ -42,6 +42,8 @@ Attributes
 |<tt>['beaver']['files']</tt>|Array|Array containing hashes like `{ 'path' => '/var/log/syslog', 'type' => 'syslogs', 'tags' => 'sys, syslog' }` for files to watch|<tt>[]</tt>|
 |<tt>['beaver']['input_type']['tcp/ampq/etc']</tt>|Hash|Key/Value [input_types](http://beaver.readthedocs.org/en/latest/search.html?q=type&check_keywords=yes&area=default)|
 |<tt>['beaver']['output']</tt>|Hash|Key/Value|
+|<tt>['poise-python']['beaver']['provider']</tt>|String|Python provider to install with. See poise-python for details.|<tt>system</tt>|
+|<tt>['poise-python']['beaver']['version']</tt>|String|Python version to install. Blank means any. Beaver only supports 2 as of v36.|<tt>'2'</tt>|
 
 Resources/Providers
 -------------------
@@ -139,7 +141,6 @@ through it.
     }
   },
   "run_list": [
-    "recipe[python]",
     "recipe[beaver]"
   ],
 }

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -69,3 +69,7 @@ else
     }
   ]
 end
+
+# Beaver only supports Python 2 at present.
+default['poise-python']['beaver']['provider'] = 'system'
+default['poise-python']['beaver']['version'] = '2'

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.5.0'
 recipe           'beaver', 'Installs and configures beaver to ship logs to logstash'
 
-%w(python apt).each do |cookbook|
+%w(poise-python apt).each do |cookbook|
   depends cookbook
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,7 +24,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 
-include_recipe 'python'
+python_runtime 'beaver'
 
 user node['beaver']['user'] do
   action :create
@@ -46,25 +46,30 @@ group node['beaver']['group'] do
   not_if { node['beaver']['group'] == 'root' }
 end
 
-python_virtualenv '/opt/beaver' do
-  interpreter 'python'
-  owner 'root'
+python_virtualenv node['beaver']['virtualenv_path'] do
+  python 'beaver'
+  user 'root'
   group 'root'
   action :create
   only_if {node['beaver']['use_virtualenv']}
 end
 
-python_pip 'setuptools-venv' do
+python_package 'setuptools-venv' do
   package_name 'setuptools'
-  virtualenv '/opt/beaver'
+  virtualenv node['beaver']['virtualenv_path']
   action :upgrade
   only_if {node['beaver']['use_virtualenv']}
 end
 
-python_pip 'beaver' do
+python_package 'beaver' do
   version node['beaver']['version']
-  virtualenv node['beaver']['virtualenv_path'] if node['beaver']['use_virtualenv']
   action :install
+
+  if node['beaver']['use_virtualenv']
+    virtualenv node['beaver']['virtualenv_path']
+  else
+    python 'beaver'
+  end
 end
 
 directory node['beaver']['config_path'] do


### PR DESCRIPTION
The python cookbook has long been deprecated and doesn't support installing from behind proxies.

This may install Python 3 in cases where 2 was chosen before. Some older distro versions like Ubuntu 12.04 install Python 3.2 by default and this is subsequently found to be too old. Some additional logic is
therefore necessary but do we care about these older versions? It's easy to override in any case.

This has been done in a bit of a hurry so you may want to wait till the new year when I'll do some more testing. I'll also be adding a systemd init script. Just thought I'd get it pushed out early for observation.