### PR TITLE
systemd init script

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -117,44 +117,27 @@ template "#{node['beaver']['config_path']}/#{node['beaver']['config_file']}" do
   notifies :restart, 'service[beaver]'
 end
 
-# setup the appropriate init script for the platform
-if node['platform'] == 'ubuntu' && node['platform_version'].to_f >= 12.04
-  template '/etc/init/beaver.conf' do
+upstart = node['platform'] == 'ubuntu' && node['platform_version'].to_f >= 12.04
+
+template 'beaver init script' do
+  owner 'root'
+  group 'root'
+  variables node['beaver']
+  notifies :restart, 'service[beaver]'
+
+  if upstart
+    path '/etc/init/beaver.conf'
     source 'beaver-upstart.erb'
-    owner node['beaver']['user']
-    group node['beaver']['group']
     mode '0644'
-    variables(
-      :config_path => node['beaver']['config_path'],
-      :config_file => node['beaver']['config_file'],
-      :log_path => node['beaver']['log_path'],
-      :log_file => node['beaver']['log_file'],
-      :pid_file => node['beaver']['pid_file'],
-      :user => node['beaver']['user'],
-      :group => node['beaver']['group']
-    )
-    notifies :restart, 'service[beaver]'
-  end
-else
-  template '/etc/init.d/beaver' do
+  else
+    path '/etc/init.d/beaver'
     source 'beaver-init.erb'
-    owner node['beaver']['user']
-    group node['beaver']['group']
     mode '0755'
-    variables(
-      :config_path => node['beaver']['config_path'],
-      :config_file => node['beaver']['config_file'],
-      :log_path => node['beaver']['log_path'],
-      :log_file => node['beaver']['log_file'],
-      :pid_file => node['beaver']['pid_file'],
-      :user => node['beaver']['user']
-    )
-    notifies :restart, 'service[beaver]'
   end
 end
 
 service 'beaver' do
-  provider Chef::Provider::Service::Upstart if node['platform'] == 'ubuntu' && node['platform_version'].to_f >= 12.04
+  provider Chef::Provider::Service::Upstart if upstart
   supports :start => true, :restart => true, :stop => true, :status => true
   action [:enable, :start]
 end

--- a/templates/default/beaver-init.erb
+++ b/templates/default/beaver-init.erb
@@ -27,8 +27,8 @@ BEAVER_LOG='<%= File.join(@log_path, @log_file) %>'
 
 
 PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-<% if node['beaver']['use_virtualenv'] %>
-PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:<%= node['beaver']['virtualenv_path'] %>/bin'
+<% if @use_virtualenv %>
+PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:<%= @virtualenv_path %>/bin'
 <% else %>
 PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
 <% end %>
@@ -49,8 +49,8 @@ do_start() {
         return 0
     fi
     echo -n $"Log Sender server daemon: ${BEAVER_NAME}"
-    <% if node['beaver']['use_virtualenv'] %>
-    su - "${BEAVER_USER}" -s '/bin/bash' -c "PATH=$PATH:<%= node['beaver']['virtualenv_path'] %>/bin ${BEAVER_CMD} >> ${BEAVER_LOG} 2>&1 & echo \$! > ${BEAVER_PID}"
+    <% if @use_virtualenv %>
+    su - "${BEAVER_USER}" -s '/bin/bash' -c "PATH=$PATH:<%= @virtualenv_path %>/bin ${BEAVER_CMD} >> ${BEAVER_LOG} 2>&1 & echo \$! > ${BEAVER_PID}"
     <% else %>
     su - "${BEAVER_USER}" -s '/bin/bash' -c "${BEAVER_CMD} >> ${BEAVER_LOG} 2>&1 & echo \$! > ${BEAVER_PID}"
     <% end %>

--- a/templates/default/beaver-upstart.erb
+++ b/templates/default/beaver-upstart.erb
@@ -17,8 +17,8 @@ setuid <%= @user %>
 setgid <%= @group %>
 
 script
-<% if node['beaver']['use_virtualenv'] %>
-exec <%= node['beaver']['virtualenv_path'] %>/bin/beaver -c <%= @config_path %>/<%= @config_file %> -l <%= @log_path %>/<%= @log_file %> -P <%= @pid_file %>
+<% if @use_virtualenv %>
+exec <%= @virtualenv_path %>/bin/beaver -c <%= @config_path %>/<%= @config_file %> -l <%= @log_path %>/<%= @log_file %> -P <%= @pid_file %>
 <% else %>
 exec beaver -c <%= @config_path %>/<%= @config_file %> -l <%= @log_path %>/<%= @log_file %> -P <%= @pid_file %>
 <% end %>

--- a/templates/default/beaver.service.erb
+++ b/templates/default/beaver.service.erb
@@ -1,0 +1,13 @@
+[Unit]
+Description=Beaver
+After=network.target
+
+[Service]
+Type=simple
+User=<%= @user %>
+Group=<%= @group %>
+ExecStart=<%= @use_virtualenv ? (@virtualenv_path + '/bin/') : '/usr/bin/env PATH=/usr/local/bin:/usr/bin ' %>beaver -c <%= File.join(@config_path, @config_file) %> -l <%= File.join(@log_path, @log_file) %>
+StandardOutput=null
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The traditional init script is a bit brain damaged as it writes everything to the log twice and writes a PID file when Beaver itself already does that. I didn't touch it as I know it comes from upstream and I thought a systemd script would be good to have anyway.
