### PR TITLE
extending with beaver startup options

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -28,6 +28,7 @@ default['beaver'] = {
   'version' => '31',
   'user' => 'root',
   'group' => 'root',
+  'startup_options' => '',
   'log_path' => '/var/log',
   'log_file' => 'beaver.log',
   'pid_file' => '/var/run/beaver.pid',

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -130,6 +130,7 @@ if node['platform'] == 'ubuntu' && node['platform_version'].to_f >= 12.04
     group node['beaver']['group']
     mode '0644'
     variables(
+      :startup_options => node['beaver']['startup_options'],
       :config_path => node['beaver']['config_path'],
       :config_file => node['beaver']['config_file'],
       :log_path => node['beaver']['log_path'],
@@ -147,6 +148,7 @@ else
     group node['beaver']['group']
     mode '0755'
     variables(
+      :startup_options => node['beaver']['startup_options'],
       :config_path => node['beaver']['config_path'],
       :config_file => node['beaver']['config_file'],
       :log_path => node['beaver']['log_path'],

--- a/templates/default/beaver-init.erb
+++ b/templates/default/beaver-init.erb
@@ -20,7 +20,7 @@
 
 
 BEAVER_NAME='beaver'
-BEAVER_CMD='beaver -c <%= File.join(@config_path, @config_file) %> -l <%= File.join(@log_path, @log_file) %> -P <%= @pid_file %>'
+BEAVER_CMD='beaver <% if @startup_options != '' -%><%= @startup_options %><% end -%> -c <%= File.join(@config_path, @config_file) %> -l <%= File.join(@log_path, @log_file) %> -P <%= @pid_file %>'
 BEAVER_PID='/var/run/beaver.pid'
 BEAVER_USER='<%= @user %>'
 BEAVER_LOG='<%= File.join(@log_path, @log_file) %>'

--- a/templates/default/beaver-upstart.erb
+++ b/templates/default/beaver-upstart.erb
@@ -20,6 +20,6 @@ script
 <% if node['beaver']['use_virtualenv'] %>
 exec <%= node['beaver']['virtualenv_path'] %>/bin/beaver -c <%= @config_path %>/<%= @config_file %> -l <%= @log_path %>/<%= @log_file %> -P <%= @pid_file %>
 <% else %>
-exec beaver -c <%= @config_path %>/<%= @config_file %> -l <%= @log_path %>/<%= @log_file %> -P <%= @pid_file %>
+exec beaver <% if @startup_options != '' -%><%= @startup_options %><% end -%> -c <%= @config_path %>/<%= @config_file %> -l <%= @log_path %>/<%= @log_file %> -P <%= @pid_file %>
 <% end %>
 end script


### PR DESCRIPTION
The purpose is to extend the init scripts with some options to start beaver, example:

beaver **--format raw** -c /etc/beaver/beaver.conf -l /var/log/beaver.log -P /var/run/beaver.pid